### PR TITLE
Implement Access & Refresh Token Authentication Flow

### DIFF
--- a/backend/src/main/java/com/habitxp/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/habitxp/backend/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.habitxp.backend.controller;
 
-import com.habitxp.backend.dto.AuthResponse;
-import com.habitxp.backend.dto.LoginRequest;
-import com.habitxp.backend.dto.RegisterRequest;
+import com.habitxp.backend.dto.*;
+import com.habitxp.backend.model.User;
+import com.habitxp.backend.security.JwtService;
 import com.habitxp.backend.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtService jwtService;
 
     @PostMapping("/register")
     public ResponseEntity<AuthResponse> register(@RequestBody RegisterRequest request) {
@@ -26,5 +27,29 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@RequestBody RefreshRequest request) {
+        String refreshToken = request.getRefreshToken();
+
+        if (!jwtService.isTokenValid(refreshToken)) {
+            return ResponseEntity.status(401).body("Refresh token invalid or expired.");
+        }
+
+        String email = jwtService.extractEmail(refreshToken);
+        User user = authService.getUserByEmail(email);
+
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            return ResponseEntity.status(401).body("Refresh token mismatch.");
+        }
+
+        String newAccessToken = jwtService.generateAccessToken(email);
+        String newRefreshToken = jwtService.generateRefreshToken(email);
+
+        user.setRefreshToken(newRefreshToken);
+        authService.saveUser(user);
+
+        return ResponseEntity.ok(new TokenResponse(newAccessToken, newRefreshToken));
     }
 }

--- a/backend/src/main/java/com/habitxp/backend/dto/AuthResponse.java
+++ b/backend/src/main/java/com/habitxp/backend/dto/AuthResponse.java
@@ -6,5 +6,6 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class AuthResponse {
-    private String token;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/backend/src/main/java/com/habitxp/backend/dto/RefreshRequest.java
+++ b/backend/src/main/java/com/habitxp/backend/dto/RefreshRequest.java
@@ -1,0 +1,8 @@
+package com.habitxp.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class RefreshRequest {
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/habitxp/backend/dto/TokenResponse.java
+++ b/backend/src/main/java/com/habitxp/backend/dto/TokenResponse.java
@@ -1,0 +1,13 @@
+package com.habitxp.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/habitxp/backend/model/User.java
+++ b/backend/src/main/java/com/habitxp/backend/model/User.java
@@ -19,6 +19,7 @@ public class User {
 
     @Id
     private String id;
+    private String refreshToken;
 
     private String firstName;
     private String lastName;

--- a/backend/src/main/java/com/habitxp/backend/security/JwtService.java
+++ b/backend/src/main/java/com/habitxp/backend/security/JwtService.java
@@ -19,13 +19,22 @@ public class JwtService {
         return Keys.hmacShaKeyFor(jwtSecret.getBytes());
     }
 
-    private final long EXPIRATION_TIME = 1000 * 60 * 60 * 24; // 24h
+    private final long ACCESS_EXPIRATION = 1000 * 60 * 15; // 15 Minuten
+    private final long REFRESH_EXPIRATION = 1000L * 60 * 60 * 24 * 7; // 7 Tage
 
-    public String generateToken(String userEmail) {
+    public String generateAccessToken(String userEmail) {
+        return buildToken(userEmail, ACCESS_EXPIRATION);
+    }
+
+    public String generateRefreshToken(String userEmail) {
+        return buildToken(userEmail, REFRESH_EXPIRATION);
+    }
+
+    public String buildToken(String subject, long expiration) {
         return Jwts.builder()
-                .setSubject(userEmail)
+                .setSubject(subject)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -37,5 +46,17 @@ public class JwtService {
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/backend/src/main/java/com/habitxp/backend/service/AuthService.java
+++ b/backend/src/main/java/com/habitxp/backend/service/AuthService.java
@@ -72,5 +72,13 @@ public class AuthService {
 
         String token = jwtService.generateToken(user.getEmail());
         return new AuthResponse(token);
+
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+    }
+
+    public void saveUser(User user) {
+        userRepository.save(user);
     }
 }

--- a/mobile/context/AuthContext.tsx
+++ b/mobile/context/AuthContext.tsx
@@ -17,7 +17,7 @@ export const AuthProvider = ({children}: { children: React.ReactNode }) => {
     useEffect(() => {
         const loadSession = async () => {
             try {
-                const storedToken = await SecureStore.getItemAsync('token');
+                const storedToken = await SecureStore.getItemAsync('accessToken');
                 if (storedToken) {
                     api.defaults.headers.common['Authorization'] = `Bearer ${storedToken}`;
                     const res = await api.get('/user/profile');
@@ -52,11 +52,13 @@ export const AuthProvider = ({children}: { children: React.ReactNode }) => {
 
         try {
             const res = await api.post('/auth/login', {email, password});
-            const jwt = res.data.token;
-            await SecureStore.setItemAsync('token', jwt);
-            api.defaults.headers.common['Authorization'] = `Bearer ${jwt}`;
+            const {accessToken, refreshToken} = res.data;
+            await SecureStore.setItemAsync('accessToken', accessToken);
+            await SecureStore.setItemAsync('refreshToken', refreshToken);
+
+            api.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
             setUser(res.data.user);
-            setToken(jwt);
+            setToken(accessToken);
         } catch (error: any) {
             console.log("Login fehlgeschlagen:", error.response?.data || error.message);
             throw error;
@@ -65,12 +67,14 @@ export const AuthProvider = ({children}: { children: React.ReactNode }) => {
 
     const register = async (data: RegisterRequest) => {
         const res = await api.post('/auth/register', data);
-        const jwt = res.data.token;
-        await SecureStore.setItemAsync('token', jwt);
-        api.defaults.headers.common['Authorization'] = `Bearer ${jwt}`;
+        const {accessToken, refreshToken} = res.data;
+        await SecureStore.setItemAsync('accessToken', accessToken);
+        await SecureStore.setItemAsync('refreshToken', refreshToken);
+
+        api.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
         const profile = await api.get("/user/profile");
         setUser(profile.data);
-        setToken(jwt);
+        setToken(accessToken);
         router.replace(ROUTES.DASHBOARD);
     };
 

--- a/mobile/context/AuthContext.tsx
+++ b/mobile/context/AuthContext.tsx
@@ -79,7 +79,8 @@ export const AuthProvider = ({children}: { children: React.ReactNode }) => {
     };
 
     const logout = async () => {
-        await SecureStore.deleteItemAsync('token');
+        await SecureStore.deleteItemAsync('accessToken');
+        await SecureStore.deleteItemAsync('refreshToken');
         setUser(null);
         setToken(null);
         router.replace(ROUTES.LOGIN);

--- a/mobile/lib/api.ts
+++ b/mobile/lib/api.ts
@@ -1,5 +1,8 @@
 import axios from "axios";
 import Constants from "expo-constants";
+import * as SecureStore from "expo-secure-store";
+import {router} from "expo-router";
+import {ROUTES} from "@/routes";
 
 const api = axios.create({
     baseURL: Constants.expoConfig?.extra?.API_URL,
@@ -7,5 +10,54 @@ const api = axios.create({
         "Content-Type": "application/json",
     },
 });
+
+api.interceptors.response.use(
+    response => response,
+    async error => {
+        const originalRequest = error.config;
+
+        if (
+            error.response?.status === 401 &&
+            !originalRequest._retry
+        ) {
+            originalRequest._retry = true;
+
+            try {
+                const refreshToken = await SecureStore.getItemAsync('refreshToken');
+                if (!refreshToken) throw new Error("Kein Refresh Token vorhanden");
+
+                const res = await axios.post(`${Constants.expoConfig?.extra?.API_URL}/auth/refresh`, {
+                    refreshToken,
+                });
+
+                const {accessToken, refreshToken: newRefreshToken} = res.data;
+
+                await SecureStore.setItemAsync("accessToken", accessToken);
+                await SecureStore.setItemAsync("refreshToken", newRefreshToken);
+
+                api.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
+                originalRequest.headers["Authorization"] = `Bearer ${accessToken}`;
+
+                return api(originalRequest);
+            } catch (refreshError: unknown) {
+                console.log("Token refresh fehlgeschlagen", refreshError);
+
+                await SecureStore.deleteItemAsync("accessToken");
+                await SecureStore.deleteItemAsync("refreshToken");
+                router.replace(ROUTES.LOGIN);
+
+                const error = refreshError instanceof Error
+                    ? refreshError
+                    : new Error("Unbekannter Fehler beim Token-Refresh");
+
+                return Promise.reject(error);
+            }
+        }
+
+        return Promise.reject(
+            error instanceof Error ? error : new Error("Unbekannter API-Fehler")
+        );
+    }
+)
 
 export default api;


### PR DESCRIPTION
### Backend Changes

- Added `/auth/refresh` endpoint in `AuthController`
- Extended `User` model with `refreshToken`
- Added `generateAccessToken()` and `generateRefreshToken()` in `JwtService`
- Tokens are now rotated and stored securely

---

### Frontend Changes

- Stored `accessToken` and `refreshToken` separately in SecureStore
- Axios interceptor added for automatic token refresh on 401
- Improved `AuthProvider` session loading and logout logic

---

### How to test

1. Register or login in the app
2. Let the `accessToken` expire (15 minutes or manually via backend)
3. Trigger an API request → it should auto-refresh using `refreshToken`
4. Check MongoDB – `refreshToken` should rotate on each refresh
5. Logout clears both tokens
